### PR TITLE
Bugfix Vault initialisation test retries

### DIFF
--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -19,9 +19,9 @@
   uri:
     url: "https://{{ vault_vip_url }}:8200/v1/sys/init"
   register: vault_init_status
-  retries: 10
-  delay: 2
-  until: result.failed is not defined
+  retries: 50
+  delay: 1
+  until: vault_init_status.status == 200
 
 - name: Initialize vault
   command: "docker exec -e 'VAULT_ADDR=https://{{ vault_vip_url }}:8200' {{ vault_docker_name }} vault operator init -format yaml"

--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -32,7 +32,9 @@
 - name: Set fact
   set_fact:
     vault_keys: "{{ vault_init_output.stdout | from_yaml }}"
+  when: not vault_init_status.json.initialized
 
 - name: Print vault keys
   debug:
     var: vault_keys
+  when: not vault_init_status.json.initialized

--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -21,6 +21,7 @@
   register: vault_init_status
   retries: 10
   delay: 2
+  until: result is not failed
 
 - name: Initialize vault
   command: "docker exec -e 'VAULT_ADDR=https://{{ vault_vip_url }}:8200' {{ vault_docker_name }} vault operator init -format yaml"

--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -21,7 +21,7 @@
   register: vault_init_status
   retries: 10
   delay: 2
-  until: result is not failed
+  until: result.failed is not defined
 
 - name: Initialize vault
   command: "docker exec -e 'VAULT_ADDR=https://{{ vault_vip_url }}:8200' {{ vault_docker_name }} vault operator init -format yaml"


### PR DESCRIPTION
This adds `until:` directive when testing if Vault is initialised. Without `until`, [the task never gets retried](https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#retrying-a-task-until-a-condition-is-met).

Additionally, added tests to check if Vault has been initialised before and if so, not do anything with the vault keys returned on first-run.