### PR TITLE
Allow the full vault_vip_address to be specified

### DIFF
--- a/roles/vault/README.md
+++ b/roles/vault/README.md
@@ -18,7 +18,7 @@ Role variables
 * Vault
   * Mandatory
     * `vault_cluster_name`: Vault cluster name (e.g. "prod_cluster")
-    * `vault_vip_address`: Vault API addr, including protocol and port (e.g. "http://127.0.0.1:8200")
+    * `vault_api_addr`: Vault [API addr](https://www.vaultproject.io/docs/configuration#api_addr) - Full URL including protocol and port (e.g. "http://127.0.0.1:8200")
     * `vault_bind_address`: Which IP address should Vault bind to
     * `vault_tls_key`: Path to TLS key to use by Vault
     * `vault_tls_cert`: Path to TLS cert to use by Vault
@@ -73,7 +73,7 @@ Example playbook (used with OpenStack Kayobe)
       consul_bind_ip: "{{ internal_net_ips[ansible_hostname] }}"
       consul_vip_address: "{{ internal_net_vip_address }}"
       vault_bind_address: "{{ external_net_ips[ansible_hostname] }}"
-      vault_vip_address: "{{ external_net_fqdn }}"
+      vault_api_addr: "https://{{ external_net_fqdn }}:8200"
       vault_config_dir: "/opt/kayobe/vault"
 ```
 

--- a/roles/vault/README.md
+++ b/roles/vault/README.md
@@ -18,6 +18,7 @@ Role variables
 * Vault
   * Mandatory
     * `vault_cluster_name`: Vault cluster name (e.g. "prod_cluster")
+    * `vault_vip_url`: Vault API addr, including protocol and port (e.g. "http://127.0.0.1:8200")
     * `vault_tls_key`: Path to TLS key to use by Vault
     * `vault_tls_cert`: Path to TLS cert to use by Vault
   * Optional

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -16,7 +16,7 @@ vault_config: >
   {
     "cluster_name": "{{ vault_cluster_name }}",
     "ui": true,
-    "api_addr": "https://{{ vault_vip_url }}:8200",
+    "api_addr": "{{ vault_vip_url }}",
     "listener": [{
       "tcp": {
         "address": "{{ vault_bind_address }}:8200",

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -21,7 +21,7 @@ vault_config: >
   {
     "cluster_name": "{{ vault_cluster_name }}",
     "ui": true,
-    "api_addr": "{{ vault_vip_url }}",
+    "api_addr": "{{ vault_vip_address }}",
     "listener": [{
       "tcp": {
         "address": "{{ vault_bind_address }}:8200",

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -9,8 +9,9 @@ vault_docker_image: "vault"
 vault_docker_tag: "latest"
 
 vault_cluster_name: ""
-# Allow vault_vip_url for backwards compatibility.
-vault_api_addr: "{{ vault_vip_url | default('') }}"
+# Allow vault_vip_url and vault_vip_address for backwards compatibility.
+vault_vip_address: "{{ vault_vip_url | default('') }}"
+vault_api_addr: "{{ ('https://' ~ vault_vip_address ~ ':8200') if vault_vip_address else '' }}"
 vault_bind_address: ""
 vault_tls_key: ""
 vault_tls_cert: ""

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -10,7 +10,7 @@ vault_docker_tag: "latest"
 
 vault_cluster_name: ""
 # Allow vault_vip_url for backwards compatibility.
-vault_vip_address: "{{ vault_vip_url | default('') }}"
+vault_api_addr: "{{ vault_vip_url | default('') }}"
 vault_bind_address: ""
 vault_tls_key: ""
 vault_tls_cert: ""
@@ -21,7 +21,7 @@ vault_config: >
   {
     "cluster_name": "{{ vault_cluster_name }}",
     "ui": true,
-    "api_addr": "{{ vault_vip_address }}",
+    "api_addr": "{{ vault_api_addr }}",
     "listener": [{
       "tcp": {
         "address": "{{ vault_bind_address }}:8200",

--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -17,14 +17,14 @@
 
 - name: Check if vault is initialized
   uri:
-    url: "{{ (vault_tls_key | length == 0) | ternary('http', 'https') }}://{{ vault_vip_url }}:8200/v1/sys/init"
+    url: "{{ vault_vip_url }}/v1/sys/init"
   register: vault_init_status
   retries: 50
   delay: 1
   until: vault_init_status.status == 200
 
 - name: Initialize vault
-  command: "docker exec -e 'VAULT_ADDR=https://{{ vault_vip_url }}:8200' {{ vault_docker_name }} vault operator init -format yaml"
+  command: "docker exec -e 'VAULT_ADDR={{ vault_vip_url }}' {{ vault_docker_name }} vault operator init -format yaml"
   when: not vault_init_status.json.initialized
   run_once: True
   register: vault_init_output

--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -17,7 +17,7 @@
 
 - name: Check if vault is initialized
   uri:
-    url: "https://{{ vault_vip_url }}:8200/v1/sys/init"
+    url: "{{ (vault_tls_key | length == 0) | ternary('http', 'https') }}://{{ vault_vip_url }}:8200/v1/sys/init"
   register: vault_init_status
   retries: 50
   delay: 1

--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -17,14 +17,14 @@
 
 - name: Check if vault is initialized
   uri:
-    url: "{{ vault_vip_address }}/v1/sys/init"
+    url: "{{ vault_api_addr }}/v1/sys/init"
   register: vault_init_status
   retries: 50
   delay: 1
   until: vault_init_status.status == 200
 
 - name: Initialize vault
-  command: "docker exec -e 'VAULT_ADDR={{ vault_vip_address }}' {{ vault_docker_name }} vault operator init -format yaml"
+  command: "docker exec -e 'VAULT_ADDR={{ vault_api_addr }}' {{ vault_docker_name }} vault operator init -format yaml"
   when: not vault_init_status.json.initialized
   run_once: True
   register: vault_init_output


### PR DESCRIPTION
This allows the full `vault_vip_address` including protocol and port to be specified as a single string. 

Previously, tasks like https://github.com/stackhpc/ansible-collection-hashicorp/blob/master/roles/vault/tasks/vault.yml#L20 hard-coded the protocol and port, limiting options (for example) for running without TLS, if TLS were to be terminated elsewhere.

