### PR TITLE
CI: pin rich to <11

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,8 @@ jobs:
           else
               ansible_package=ansible-core
           fi
-          pip install $ansible_package==${{ matrix.ansible }}.* 'ansible-lint<5'
+          # FIXME: rich pinned due to https://github.com/ansible-community/ansible-lint/issues/1795.
+          pip install $ansible_package==${{ matrix.ansible }}.* 'rich<11' 'ansible-lint<5'
 
       - name: Linting code
         run: |


### PR DESCRIPTION
This library is used by ansible-lint and introduced a breaking change in 11.0.