### PR TITLE
Set a restart policy for deployed containers

### DIFF
--- a/roles/vault/tasks/consul.yml
+++ b/roles/vault/tasks/consul.yml
@@ -8,6 +8,7 @@
     volumes: "{{ _consul_volumes }}"
     comparisons:
       '*': strict
+    restart_policy: "always"
     env:
       CONSUL_BIND_INTERFACE: "{{ consul_bind_interface }}"
       CONSUL_CLIENT_INTERFACE: "{{ consul_bind_interface }}"

--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -9,6 +9,7 @@
     volumes: "{{ _vault_volumes }}"
     comparisons:
       '*': strict
+    restart_policy: "always"
     env:
       VAULT_LOCAL_CONFIG: "{{ vault_config | to_json }}"
     command: >


### PR DESCRIPTION
On reboot, Vault and Consul containers were not starting.  Change
the restart_policy to 'always' to ensure the services restart.