### PR TITLE
Add support for login to Docker registry

### DIFF
--- a/roles/vault/README.md
+++ b/roles/vault/README.md
@@ -12,6 +12,10 @@ Role variables
     * `consul_docker_image`: Docker image for Consul (default: "consul")
     * `consul_docker_tag`: Docker image tag for Consul (default: "latest")
     * `consul_docker_volume`: Docker volume name for Consul data (default: "consul_data")
+    * `consul_container`: Additional data for pulling and configuring the Consul container
+      * `etc_hosts`: Dict of `{<hostname>:<ip_address>}` to be added to container /etc/hosts (default: Omitted)
+      * `registry_user`: Username for login to private Docker registry (default: Omitted)
+      * `registry_password`: Password for login to private Docker registry (default: Omitted)
     * `consul_container.etc_hosts`: Dict of `{<hostname>:<ip_address>}` to be added to container /etc/hosts (default: Omitted)
     * `consul_extra_volumes`: List of `"<host_location>:<container_mountpoint>"`
 

--- a/roles/vault/tasks/main.yml
+++ b/roles/vault/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Login to remote registry
+  docker_login:
+    username: "{{ consul_container.registry_user }}"
+    password: "{{ consul_container.registry_password }}"
+    registry_url: "{{ consul_container.registry_url }}"
+  when: "'registry_user' in consul_container"
+  become: true
+
 - import_tasks: prechecks.yml
 - import_tasks: consul.yml
 - import_tasks: vault.yml


### PR DESCRIPTION
Perform a Docker registry login before container pull, if credentials
are defined (for the Consul container, but applicable to both).