### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,10 @@
+[defaults]
+# Use the YAML stdout callback plugin.
+stdout_callback = yaml
+# Use the stdout_callback when running ad-hoc commands.
+bin_ansible_callbacks = True
+# Disable fact variable injection to improve performance.
+inject_facts_as_vars = False
+   
+[ssh_connection]
+pipelining = True

--- a/roles/vault/README.md
+++ b/roles/vault/README.md
@@ -103,8 +103,8 @@ Example playbook (used with OpenStack Kayobe)
   roles:
     - role: stackhpc.hashicorp.vault
       consul_bind_interface: "{{ internal_net_interface }}"
-      consul_bind_ip: "{{ internal_net_ips[ansible_hostname] }}"
-      vault_bind_address: "{{ external_net_ips[ansible_hostname] }}"
+      consul_bind_ip: "{{ internal_net_ips[inventory_hostname] }}"
+      vault_bind_address: "{{ external_net_ips[inventory_hostname] }}"
       vault_api_addr: "https://{{ external_net_fqdn }}:8200"
       vault_config_dir: "/opt/kayobe/vault"
 ```

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -48,7 +48,7 @@ vault_config: >
   }
 
 consul_bind_interface: ""
-consul_bind_ip: "{{ hostvars[inventory_hostname]['ansible_'~consul_bind_interface].ipv4.address }}"
+consul_bind_ip: "{{ hostvars[inventory_hostname].ansible_facts[consul_bind_interface].ipv4.address }}"
 
 # Docker options
 vault_container: {}

--- a/roles/vault/tasks/consul.yml
+++ b/roles/vault/tasks/consul.yml
@@ -14,13 +14,13 @@
       CONSUL_CLIENT_INTERFACE: "{{ consul_bind_interface }}"
     command: >
       consul agent
-      -bind "{{  hostvars[inventory_hostname]['ansible_'~consul_bind_interface].ipv4.address }}"
+      -bind "{{  hostvars[inventory_hostname].ansible_facts[consul_bind_interface].ipv4.address }}"
       -data-dir /consul/data
       -server
       -bootstrap-expect "{{ ansible_play_hosts | length }}"
       {% for host in ansible_play_hosts %}
       {% if host != inventory_hostname %}
-      -retry-join "{{ hostvars[host]['ansible_'~consul_bind_interface].ipv4.address }}"
+      -retry-join "{{ hostvars[host].ansible_facts[consul_bind_interface].ipv4.address }}"
       {% endif %}
       {% endfor %}
   become: True


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars
