### PR TITLE
vault: Introduce vault_init_addr

### DIFF
--- a/roles/vault/README.md
+++ b/roles/vault/README.md
@@ -29,6 +29,7 @@ Role variables
   * Optional
     * `vault_bind_address`: Which IP address should Vault bind to (default: "127.0.0.1")
     * `vault_api_addr`: Vault [API addr](https://www.vaultproject.io/docs/configuration#api_addr) - Full URL including protocol and port (default: "http://127.0.0.1:8200")
+    * `vault_init_addr`: Vault init addr (used only for initialisation purposes) - full URL including protocol and port (default: "http://127.0.0.1:8200")
     * `consul_container.etc_hosts`: Dict; `{<hostname>:<ip_address>}` to be added to container /etc/host
 s (default: Omitted)
     * `vault_extra_volumes`: List of `"<host_location>:<container_mountpoint>"`

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -14,6 +14,7 @@ vault_protocol: "{{ 'https' if vault_tls_key and vault_tls_cert else 'http' }}"
 vault_vip_address: "{{ vault_vip_url | default(vault_bind_address) }}"
 vault_api_addr: "{{ vault_protocol ~ '://' ~ vault_vip_address ~ ':8200' }}"
 vault_bind_address: "127.0.0.1"
+vault_init_addr: "http://127.0.0.1:8200"
 vault_tls_key: ""
 vault_tls_cert: ""
 

--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -18,7 +18,7 @@
 
 - name: Check if vault is initialized
   uri:
-    url: "{{ vault_api_addr }}/v1/sys/init"
+    url: "{{ vault_init_addr }}/v1/sys/init"
   register: vault_init_status
   retries: 50
   delay: 1
@@ -29,7 +29,7 @@
   block:
     - name: Initialize vault
       hashivault_init:
-        url: "{{ vault_api_addr }}"
+        url: "{{ vault_init_addr }}"
         ca_cert: "{{ vault_ca_cert | default(omit) }}"
       no_log: true
       register: vault_keys_result


### PR DESCRIPTION
Since by default we always bind to http://127.0.0.1:8200, let's use this address for init.