### PR TITLE
allow to generate separate Intermediate CA cert as well as bundle

### DIFF
--- a/roles/vault_pki/tasks/intermediate.yml
+++ b/roles/vault_pki/tasks/intermediate.yml
@@ -72,7 +72,7 @@
       copy:
         content: |
           {{ intermediate_ca_csr_signed.data.certificate }}
-        dest: "{{ vault_pki_certificates_directory }}/{{ vault_pki_intermediate_ca_name | replace(' ', '-') }}.pem"
+        dest: "{{ vault_pki_certificates_directory }}/{{ vault_pki_intermediate_ca_name | replace(' ', '-') }}.crt"
         mode: 0600
       delegate_to: "{{ vault_pki_write_certificates_host }}"
       when:

--- a/tests/test_vault.yml
+++ b/tests/test_vault.yml
@@ -98,14 +98,14 @@
         - OS-CERT-TEST2.pem
 
     - name: concatenate CAs
-      shell: | 
-        cat /tmp/OS-TLS-ROOT.pem /tmp/OS-TLS-INT.pem > /tmp/CA-CHAIN.pem
+      shell: |
+        cat /tmp/OS-TLS-ROOT.pem /tmp/OS-TLS-INT.crt > /tmp/CA-CHAIN.pem
       args:
         executable: /bin/bash
       become: true
 
     - name: verify certificate chain
-      command: | 
+      command: |
         openssl verify -CAfile /tmp/CA-CHAIN.pem
         /tmp/{{ item }}
       register: verify_result


### PR DESCRIPTION
it is useful to be able to generate both bundle and separate intermediate certificate, hence changing cert file extension.