### PR TITLE
move out from deprecated images source

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "stackhpc"
 name: "hashicorp"
-version: "2.2.0"
+version: "2.3.0"
 readme: "README.md"
 authors:
   - "Michał Nasiadka"

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 consul_docker_name: "consul"
-consul_docker_image: "consul"
+consul_docker_image: "hashicorp/consul"
 consul_docker_tag: "latest"
 consul_docker_volume: "consul_data"
 
 vault_docker_name: "vault"
-vault_docker_image: "vault"
+vault_docker_image: "hashicorp/vault"
 vault_docker_tag: "latest"
 
 vault_cluster_name: ""


### PR DESCRIPTION
old images source are deprecated. move to new ones

Upcoming in Vault 1.14, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from [hashicorp/vault](https://hub.docker.com/r/hashicorp/vault) instead of [vault](https://hub.docker.com/_/vault). Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/vault.