### PR TITLE
PKI: Fix intermediate certificate idempotency

### DIFF
--- a/roles/vault_pki/tasks/intermediate.yml
+++ b/roles/vault_pki/tasks/intermediate.yml
@@ -53,6 +53,8 @@
           {{ intermediate_ca_csr_signed.data.issuing_ca }}
       when:
         - not vault_pki_intermediate_export | bool
+        - intermediate_ca_csr.changed
+        - intermediate_ca_csr.data is defined
 
     - name: "Set Exported Intermediate as signed"
       hashivault_pki_ca_set:
@@ -78,6 +80,8 @@
       delegate_to: "{{ vault_pki_write_certificates_host }}"
       when:
         - vault_pki_write_int_ca_to_file | bool
+        - intermediate_ca_csr.changed
+        - intermediate_ca_csr.data is defined
 
     - name: "Write out Intermediate Certs and keys to file"
       copy:

--- a/tests/test_vault.yml
+++ b/tests/test_vault.yml
@@ -31,8 +31,6 @@
         vault_unseal_keys: "{{ vault_keys.keys_base64 }}"
 
     - name: Configure PKI - create root/intermediate and generate certificates
-      include_role:
-        name: vault_pki
       vars:
         vault_pki_certificate_subject:
           - role: 'ServerCert'
@@ -68,10 +66,16 @@
         vault_pki_write_pem_bundle: false
         vault_pki_write_root_ca_to_file: true
         vault_token: "{{ vault_keys.root_token }}"
+      block:
+        - name: Configure PKI - create root/intermediate and generate certificates
+          include_role:
+            name: vault_pki
+
+        - name: Configure PKI - create root/intermediate and generate certificates (idempotence test)
+          include_role:
+            name: vault_pki
 
     - name: Configure PKI - generate certificate pem bundle
-      include_role:
-        name: vault_pki
       vars:
         vault_pki_certificate_subject:
           - role: 'ServerCert'
@@ -89,6 +93,14 @@
         vault_pki_write_certificate_files: true
         vault_pki_write_pem_bundle: true
         vault_token: "{{ vault_keys.root_token }}"
+      block:
+        - name: Configure PKI - generate certificate pem bundle
+          include_role:
+            name: vault_pki
+
+        - name: Configure PKI - generate certificate pem bundle (idempotence test)
+          include_role:
+            name: vault_pki
 
     - name: Validate if certificates exist
       stat:


### PR DESCRIPTION
Fix idempotency of intermediate certificates
    
Prior to this change running the vault_pki role multiple times when generating an intermediate certificate could result in the following error:

```
    TASK [vault_pki : Set Intermediate as signed] **********************************
    fatal: [localhost]: FAILED! =>
      msg: |-
        The task includes an option with an undefined variable. The error was:
        'dict object' has no attribute 'data'
    
        The error appears to be in 'roles/vault_pki/tasks/intermediate.yml': line
        45, column 7, but may be elsewhere in the file depending on the exact
        syntax problem.
    
        The offending line appears to be:
    
            - name: "Set Intermediate as signed"
              ^ here
```
    
This change adds the same condition used in other tasks.

The tests have also been updated to cover PKI idempotency.