### PR TITLE
vault: Add logs and file volumes

### DIFF
--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -71,6 +71,8 @@ consul_container: {}
 # Default volume mapping
 _vault_default_volumes:
   - "{{ vault_config_dir }}:/vault/config"
+  - "vault_file:/vault/file"
+  - "vault_logs:/vault/logs"
 _consul_default_volumes:
   - "{{ consul_docker_volume }}:/consul/data"
 


### PR DESCRIPTION
These volumes are defined by default in the Dockerfile, therefore if not defined - they get a new volume every restart ([1]).

[1]: https://github.com/hashicorp/docker-vault/blob/152f49d818b2764c437ee1fd20ee4d13791a8296/ubi/Dockerfile#L70