### PR TITLE
[CI]: Switch to testing two latest ansible-core versions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,3 +1,4 @@
+---
 name: Tests
 
 # Controls when the action will run.
@@ -14,9 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - "2.9"
-          - "2.10"
-          - "2.12"
+          - "2.16"
+          - "2.17"
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so it's accessible to the job
       - uses: actions/checkout@v3
@@ -26,15 +26,8 @@ jobs:
           pipx uninstall ansible-core
           python3 -m pip install --upgrade pip
           ansible_version=${{ matrix.ansible }}
-          if [[ "${{ matrix.ansible }}" = "2.9" ]]; then
-              ansible_package=ansible
-          elif [[ "${{ matrix.ansible }}" = "2.10" ]]; then
-              ansible_package=ansible
-              ansible_version=3
-          else
-              ansible_package=ansible-core
-          fi
-          python3 -m pip install $ansible_package==$ansible_version.* docker git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc
+          python3 -m pip install ansible-core==$ansible_version.* docker ansible-modules-hashivault
+          ansible-galaxy collection install -r core-requirements.yml
           ansible-galaxy collection build
           ansible-galaxy collection install *.tar.gz
 

--- a/core-requirements.yml
+++ b/core-requirements.yml
@@ -1,0 +1,8 @@
+---
+collections:
+  - name: ansible.posix
+    source: https://galaxy.ansible.com
+    version: <2
+  - name: community.general
+    source: https://galaxy.ansible.com
+    version: <7


### PR DESCRIPTION
Switch to run tests against ansible-core 2.16 and 2.17 Also switch to test against latest ansible-modules-hashivault