### PR TITLE
Prevent seal-status check failing when TLS is expired

### DIFF
--- a/roles/vault_unseal/tasks/main.yml
+++ b/roles/vault_unseal/tasks/main.yml
@@ -24,6 +24,7 @@
 - name: Check if vault is sealed
   uri:
     url: "{{ vault_api_addr }}/v1/sys/seal-status"
+    validate_certs: "{{ vault_unseal_verify | default(omit) }}"
   register: vault_seal_status
 
 - name: Fail when vault is still sealed


### PR DESCRIPTION
If certificate of Vault API is expired, user needs to set ``vault_unseal_verify`` to False to avoid tasks failing.

However, checking seal-status after unsealing still tries to verify the certificate.

This fixes the issue by setting ``validate_certs`` option to also follow ``vault_unseal_verify``.