### PR TITLE
feat: bump `ansible-modules-hashivault`

### DIFF
--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -6,4 +6,4 @@ jobs:
   lint:
     uses: stackhpc/.github/.github/workflows/lint-collection.yml@main
     with:
-      lint_pip_dependencies: git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc
+      lint_pip_dependencies: git+https://github.com/stackhpc/ansible-modules-hashivault@c22434d887f0b8a5ac3ebda710664a027291e71c

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pipx uninstall ansible-core
           python3 -m pip install --upgrade pip
-          python3 -m pip install ansible-core==${{ matrix.ansible }}.* docker git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc
+          python3 -m pip install ansible-core==${{ matrix.ansible }}.* docker git+https://github.com/stackhpc/ansible-modules-hashivault@c22434d887f0b8a5ac3ebda710664a027291e71c  # yamllint disable-line rule:line-length
           ansible-galaxy collection build
           ansible-galaxy collection install *.tar.gz
 


### PR DESCRIPTION
Use `c22434d887f0b8a5ac3ebda710664a027291e71c` which corresponds to the latest release `5.3.0`.