### PR TITLE
feat: support control of enabling the user interface

### DIFF
--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -38,6 +38,7 @@ Role variables
     * `openbao_write_keys_file`: Whether to write the root token and unseal keys to a file. Default `false`
     * `openbao_write_keys_file_host`: Host on which to write root token and unseal keys. Default `localhost`
     * `openbao_write_keys_file_path`: Path of file to write root token and unseal keys. Default `bao-keys.json`
+    * `openbao_enable_ui`: Whether to enable user interface that could be accessed from the `openbao_api_addr`. Default `false` 
 
 Root and unseal keys
 --------------------

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -19,10 +19,12 @@ openbao_tls_cert: ""
 
 openbao_config_dir: ""
 
+openbao_enable_ui: false
+
 openbao_config: >
   {
     "cluster_name": "{{ openbao_cluster_name }}",
-    "ui": false,
+    "ui": "{{ openbao_enable_ui }}",
     "api_addr": "{{ openbao_api_addr }}",
     "cluster_addr": "http://127.0.0.1:8201",
     "listener": [{


### PR DESCRIPTION
The user interface can be enabled with the variable `openbao_enable_ui` it currently defaults to `false`.

If enabled the user interface can be accessed from any `OpenBao` instance via the address it has bound to via the public port which is typically `8200`.