### PR TITLE
feat: set `BAO_ADDR` at container runtime

### DIFF
--- a/roles/openbao/tasks/openbao.yml
+++ b/roles/openbao/tasks/openbao.yml
@@ -12,6 +12,7 @@
     restart_policy: "always"
     env:
       BAO_LOCAL_CONFIG: "{{ openbao_config | to_json }}"
+      BAO_ADDR: "{{ openbao_api_addr }}"
     command: >
       server
   become: true


### PR DESCRIPTION
As `BAO_ADDR` defaults to `https://127.0.0.1:8200` it means that if the configuration has choosen a different protocol, IP or port it will not work without first exporting a new variable within the shell.

We can avoid this minor inconvenience by setting `BAO_ADDR` when starting the container.