### PR TITLE
feat: add adjustable delay after unsealing the vault

### DIFF
--- a/roles/vault_unseal/README.md
+++ b/roles/vault_unseal/README.md
@@ -28,6 +28,7 @@ Role variables
 * `vault_unseal_token`: Token for Vault
 * `vault_unseal_username`: Username to login to Vault
 * `vault_unseal_verify`: If set, do not verify presented TLS certificate before communicating with Vault server.
+* `vault_unseal_timeout`: Control the delay between unsealing the vault and checking its status. Defaults to `0` seconds
 
 Example playbook
 ----------------

--- a/roles/vault_unseal/tasks/main.yml
+++ b/roles/vault_unseal/tasks/main.yml
@@ -21,6 +21,11 @@
     username: "{{ vault_unseal_username | default(omit) }}"
     verify: "{{ vault_unseal_verify | default(omit) }}"
 
+- name: Wait for vault to be unsealed
+  wait_for:
+    timeout: "{{ vault_unseal_timeout | default(0) }}"
+  delegate_to: localhost
+
 - name: Check if vault is sealed
   uri:
     url: "{{ vault_api_addr }}/v1/sys/seal-status"


### PR DESCRIPTION
It has been observed with high available Raft that followers do not unseal quickly enough and therefore the role reports a failure. By providing an adjustable delay users of the role can ensure enough time has passed before checking the sealed status.