### PR TITLE
feat: add additional `TCP` localhost listener and `leader_ca`

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@ namespace: stackhpc
 name: hashicorp
 description: >
   Hashicorp Vault/Consul deployment and configuration
-version: "2.6.1"
+version: "2.7.0"
 readme: "README.md"
 authors:
   - "Michał Nasiadka"

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -33,6 +33,7 @@ Role variables
     * `openbao_ca_cert`: Path to CA certificate used to verify OpenBao server TLS cert
     * `openbao_tls_key`: Path to TLS key to use by OpenBao
     * `openbao_tls_cert`: Path to TLS cert to use by OpenBao
+    * `openbao_tls_ca`: Path to TLS CA certificate that can be used by peers to validate the leaders TLS
     * `openbao_log_keys`: Whether to log the root token and unseal keys in the Ansible output. Default `false`
     * `openbao_set_keys_fact`: Whether to set a `openbao_keys` fact containing the root token and unseal keys. Default `false`
     * `openbao_write_keys_file`: Whether to write the root token and unseal keys to a file. Default `false`

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -13,6 +13,7 @@ openbao_cluster_name: ""
 
 openbao_tls_key: ""
 openbao_tls_cert: ""
+openbao_tls_ca: ""
 
 openbao_protocol: "{{ 'https' if openbao_tls_key and openbao_tls_cert else 'http' }}"
 
@@ -59,7 +60,9 @@ openbao_config: >
         "path": "/openbao/file",
         {% if openbao_raft_leaders | length > 0 %}
         "retry_join": {
-          "leader_api_addr": "{{ openbao_protocol }}://{{ openbao_raft_leaders | first }}:{{ openbao_api_port }}"
+          "leader_api_addr": "{{ openbao_protocol }}://{{ openbao_raft_leaders | first }}:{{ openbao_api_port }}"{% if openbao_tls_ca %},
+          "leader_ca_cert_file": "/openbao/config/{{ openbao_tls_ca }}"
+          {% endif %}
         }
         {% endif %}
       }

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -44,7 +44,14 @@ openbao_config: >
         {% else %}
         "tls_disable": "true"
         {% endif %}
+      }{% if not openbao_bind_addr.startswith('127.') %},
+    },
+    {
+      "tcp": {
+        "address": "127.0.0.1:8200",
+        "tls_disable": "true"
       }
+    {% endif %}
     }],
     "storage": {
       "raft": {


### PR DESCRIPTION
Fix two important bugs that prevent deployment of OpenBao across multiple hosts such as OpenStack control plane.

1. Ensure that the `bao` client can communicate with `bao` server via
`127.0.0.1` in situations where the `bind_addr` it not listening on
localhost.

2. If `TLS` is used on the `OpenBao` API then raft peers will need to
configured with a `CA` certificate to verify the certificates being used
by the leader otherwise then could not join.