### PR TITLE
Fix openbao_api_addr to include protocol

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -17,7 +17,7 @@ openbao_tls_ca: ""
 
 openbao_protocol: "{{ 'https' if openbao_tls_key and openbao_tls_cert else 'http' }}"
 
-openbao_api_addr: "{{ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
+openbao_api_addr: "{{ openbao_protocol ~ '://' ~ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
 openbao_bind_addr: "127.0.0.1"
 openbao_init_addr: "{{ openbao_api_addr }}"
 openbao_cluster_addr: "{{ openbao_bind_addr ~ ':' ~ openbao_cluster_port }}"

--- a/tests/test_openbao.yml
+++ b/tests/test_openbao.yml
@@ -6,14 +6,9 @@
     openbao_config_dir: "/etc/openbao"
     openbao_log_keys: true
     openbao_bind_addr: "127.0.0.1"
-    openbao_api_addr: "{{ 'http' ~ '://' ~ openbao_bind_addr ~ ':8200' }}"
     openbao_set_keys_fact: true
     openbao_write_keys_file: true
   tasks:
-    - name: Debug
-      ansible.builtin.debug:
-        var: openbao_api_addr
-
     - name: Ensure /etc/openbao exists
       ansible.builtin.file:
         path: /etc/openbao
@@ -33,7 +28,6 @@
       ansible.builtin.include_role:
         name: vault_unseal
       vars:
-        vault_api_addr: "{{ openbao_api_addr }}"
         vault_unseal_keys: "{{ openbao_keys.keys_base64 }}"
 
     - name: Configure PKI - create root/intermediate and generate certificates
@@ -71,7 +65,6 @@
         vault_pki_write_int_ca_to_file: true
         vault_pki_write_pem_bundle: false
         vault_pki_write_root_ca_to_file: true
-        vault_api_addr: "{{ openbao_api_addr }}"
         vault_token: "{{ openbao_keys.root_token }}"
       block:
         - name: Configure PKI - create root/intermediate and generate certificates
@@ -99,7 +92,6 @@
         vault_pki_root_create: false
         vault_pki_write_certificate_files: true
         vault_pki_write_pem_bundle: true
-        vault_api_addr: "{{ openbao_api_addr }}"
         vault_token: "{{ openbao_keys.root_token }}"
       block:
         - name: Configure PKI - generate certificate pem bundle

--- a/tests/test_openbao_ha.yml
+++ b/tests/test_openbao_ha.yml
@@ -4,7 +4,6 @@
   hosts: openbao_ha
   vars:
     openbao_log_keys: true
-    openbao_api_addr: "{{ 'http' ~ '://' ~ openbao_bind_addr ~ ':8200' }}"
     openbao_set_keys_fact: true
     openbao_write_keys_file: true
     openbao_raft_leaders:
@@ -14,10 +13,6 @@
       - "{{ openbao_config_dir }}/openbao_file:/openbao/file"
       - "{{ openbao_config_dir }}/openbao_logs:/openbao/logs"
   tasks:
-    - name: Debug
-      ansible.builtin.debug:
-        var: openbao_api_addr
-
     - name: Ensure /etc/openbao exists
       ansible.builtin.file:
         path: /etc/openbao
@@ -40,7 +35,6 @@
       ansible.builtin.include_role:
         name: vault_unseal
       vars:
-        vault_api_addr: "{{ openbao_api_addr }}"
         vault_unseal_keys: "{{ openbao_keys.keys_base64 }}"
       run_once: true
 
@@ -57,7 +51,6 @@
       ansible.builtin.include_role:
         name: vault_unseal
       vars:
-        vault_api_addr: "{{ openbao_api_addr }}"
         vault_unseal_keys: "{{ openbao_keys.keys_base64 }}"
         vault_unseal_timeout: 10
 
@@ -67,7 +60,6 @@
   run_once: true
   vars:
     openbao_log_keys: true
-    openbao_api_addr: "{{ 'http' ~ '://' ~ openbao_bind_addr ~ ':8200' }}"
     openbao_set_keys_fact: true
     openbao_write_keys_file: true
   tasks:
@@ -111,7 +103,6 @@
         vault_pki_write_int_ca_to_file: true
         vault_pki_write_pem_bundle: false
         vault_pki_write_root_ca_to_file: true
-        vault_api_addr: "{{ openbao_api_addr }}"
         vault_token: "{{ openbao_keys.root_token }}"
       block:
         - name: Configure PKI - create root/intermediate and generate certificates
@@ -139,7 +130,6 @@
         vault_pki_root_create: false
         vault_pki_write_certificate_files: true
         vault_pki_write_pem_bundle: true
-        vault_api_addr: "{{ openbao_api_addr }}"
         vault_token: "{{ openbao_keys.root_token }}"
       block:
         - name: Configure PKI - generate certificate pem bundle


### PR DESCRIPTION
The openbao role docs states that the default value of openbao_api_addr is 'http://127.0.0.1:8200' but it actually did not include the protocol