### PR TITLE
Pin Vault to 1.14.8 and Consul to 1.16.4

### DIFF
--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -5,12 +5,12 @@ hashicorp_registry_password: ""
 
 consul_docker_name: "consul"
 consul_docker_image: "hashicorp/consul"
-consul_docker_tag: "latest"
+consul_docker_tag: "1.16.4"
 consul_docker_volume: "consul_data"
 
 vault_docker_name: "vault"
 vault_docker_image: "hashicorp/vault"
-vault_docker_tag: "latest"
+vault_docker_tag: "1.14.8"
 
 vault_cluster_name: ""
 vault_protocol: "{{ 'https' if vault_tls_key and vault_tls_cert else 'http' }}"


### PR DESCRIPTION
Upstream latest tag for hashicorp/vault is producing error on CI. Pinning Vault and Consul to the latest version used on SKC.