### PR TITLE
Bump version in galaxy.yml to 2.8.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@ namespace: stackhpc
 name: hashicorp
 description: >
   Hashicorp Vault/Consul deployment and configuration
-version: "2.8.0"
+version: "2.8.1"
 readme: "README.md"
 authors:
   - "Michał Nasiadka"


### PR DESCRIPTION
There was an error in the tag 2.8.0 but due to enforced immutable tag, we can't re-create the tag. Bumping to 2.8.1 instead.