### PR TITLE
Fix migration unseal

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@ namespace: stackhpc
 name: hashicorp
 description: >
   Hashicorp Vault/Consul deployment and configuration
-version: "2.8.1"
+version: "2.8.2"
 readme: "README.md"
 authors:
   - "Michał Nasiadka"

--- a/playbooks/ha_migration.yml
+++ b/playbooks/ha_migration.yml
@@ -14,6 +14,7 @@
     migration_common_tls_key: ""
     migration_common_tls_cert: ""
     migration_common_tls_ca: ""
+    migration_vault_unseal_ca_cert: "{{ '/etc/pki/tls/certs/ca-bundle.crt' if ansible_facts.os_family == 'RedHat' else '/etc/ssl/certs/ca-certificates.crt' }}"
     migration_common_protocol: "{{ 'https' if migration_common_tls_key and migration_common_tls_cert else 'http' }}"
     migration_common_api_addr: "{{ migration_common_protocol ~ '://' ~ migration_common_bind_addr ~ ':' ~ migration_common_api_port }}"
     migration_openbao_registry_url: ""
@@ -88,3 +89,4 @@
       vars:
         vault_api_addr: "{{ migration_common_api_addr }}"
         vault_unseal_keys: "{{ migration_common_unseal_keys }}"
+        vault_unseal_ca_cert: "{{ migration_vault_unseal_ca_cert if migration_common_protocol == 'https' else omit }}"

--- a/roles/vault_bao_migration/README.md
+++ b/roles/vault_bao_migration/README.md
@@ -37,6 +37,7 @@ Role variables
     * `migration_common_tls_key`: Path to TLS key to use by Vault and OpenBao
     * `migration_common_tls_cert`: Path to TLS cert to use by Vault and OpenBao
     * `migration_common_tls_ca`: Path to TLS CA certificate that can be used by peers to validate the leaders TLS
+    * `migartion_vault_unseal_ca_cert`: Path to TLS CA certificate used for unsealing Vault/OpenBao. Default is system trust chain. (default: "/etc/pki/tls/certs/ca-bundle.crt" if the OS family is RedHat. Otherwise, "/etc/ssl/certs/ca-certificates.crt")
 
 * Hashicorp Vault
   * Mandatory

--- a/roles/vault_bao_migration/README.md
+++ b/roles/vault_bao_migration/README.md
@@ -37,7 +37,7 @@ Role variables
     * `migration_common_tls_key`: Path to TLS key to use by Vault and OpenBao
     * `migration_common_tls_cert`: Path to TLS cert to use by Vault and OpenBao
     * `migration_common_tls_ca`: Path to TLS CA certificate that can be used by peers to validate the leaders TLS
-    * `migartion_vault_unseal_ca_cert`: Path to TLS CA certificate used for unsealing Vault/OpenBao. Default is system trust chain. (default: "/etc/pki/tls/certs/ca-bundle.crt" if the OS family is RedHat. Otherwise, "/etc/ssl/certs/ca-certificates.crt")
+    * `migration_vault_unseal_ca_cert`: Path to TLS CA certificate used for unsealing Vault/OpenBao. Default is system trust chain. (default: "/etc/pki/tls/certs/ca-bundle.crt" if the OS family is RedHat. Otherwise, "/etc/ssl/certs/ca-certificates.crt")
 
 * Hashicorp Vault
   * Mandatory

--- a/roles/vault_bao_migration/defaults/main.yml
+++ b/roles/vault_bao_migration/defaults/main.yml
@@ -4,6 +4,7 @@ migration_common_cluster_name: "" # required
 migration_common_tls_key: ""
 migration_common_tls_cert: ""
 migration_common_tls_ca: ""
+migration_vault_unseal_ca_cert: "{{ '/etc/pki/tls/certs/ca-bundle.crt' if ansible_facts.os_family == 'RedHat' else '/etc/ssl/certs/ca-certificates.crt' }}"
 
 migration_common_protocol: "{{ 'https' if migration_common_tls_key and migration_common_tls_cert else 'http' }}"
 

--- a/roles/vault_bao_migration/tasks/raft.yml
+++ b/roles/vault_bao_migration/tasks/raft.yml
@@ -1,5 +1,5 @@
 ---
-- name: Check current stroage backend
+- name: Check current storage backend
   ansible.builtin.uri:
     url: "{{ vault_api_address }}/v1/sys/seal-status"
   vars:

--- a/roles/vault_bao_migration/tasks/raft.yml
+++ b/roles/vault_bao_migration/tasks/raft.yml
@@ -91,6 +91,7 @@
       vars:
         vault_api_addr: "{{ migration_common_api_addr }}"
         vault_unseal_keys: "{{ migration_common_unseal_keys }}"
+        vault_unseal_ca_cert: "{{ migration_vault_unseal_ca_cert if migration_common_protocol == 'https' else omit }}"
 
 - name: Join Vault followers to Raft
   when:
@@ -130,6 +131,7 @@
       vars:
         vault_api_addr: "{{ migration_common_api_addr }}"
         vault_unseal_keys: "{{ migration_common_unseal_keys }}"
+        vault_unseal_ca_cert: "{{ migration_vault_unseal_ca_cert if migration_common_protocol == 'https' else omit }}"
 
 - name: Verify all peers are joined to the cluster
   when: _vault_followers | length > 0

--- a/roles/vault_bao_migration/tasks/single_node_migration.yml
+++ b/roles/vault_bao_migration/tasks/single_node_migration.yml
@@ -84,6 +84,7 @@
   vars:
     vault_api_addr: "{{ migration_common_api_addr }}"
     vault_unseal_keys: "{{ openbao_keys.keys_base64 }}"
+    vault_unseal_ca_cert: "{{ migration_vault_unseal_ca_cert if migration_common_protocol == 'https' else omit }}"
 
 - name: Restore Raft snapshot into OpenBao
   ansible.builtin.uri:
@@ -120,6 +121,7 @@
   vars:
     vault_api_addr: "{{ migration_common_api_addr }}"
     vault_unseal_keys: "{{ migration_common_unseal_keys }}"
+    vault_unseal_ca_cert: "{{ migration_vault_unseal_ca_cert if migration_common_protocol == 'https' else omit }}"
 
 - name: Get cluster id of OpenBao
   ansible.builtin.uri:


### PR DESCRIPTION
When unsealing Vault to OpenBao during the migration process, it can fail because the vault_unseal role requires to set CA explicitly even if it's part of system trust bundle.