### PR TITLE
Support Ansible 2.20 (and fix CI)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,12 +16,20 @@ jobs:
         ansible_version:
           - "2.15"
           - "2.18"
+          - "2.20"
         python_version:
           - "3.9"
           - "3.11"
+          - "3.12"
         exclude:
+          # Python 3.9 incompatible with ansible 2.18/2.20
           - python_version: "3.9"
             ansible_version: "2.18"
+          - python_version: "3.9"
+            ansible_version: "2.20"
+          # Python 3.11 incompatible with ansible 2.20
+          - python_version: "3.11"
+            ansible_version: "2.20"
         type:
           - openbao
           - openbao_ha

--- a/playbooks/ha_migration.yml
+++ b/playbooks/ha_migration.yml
@@ -15,7 +15,7 @@
     migration_common_tls_cert: ""
     migration_common_tls_ca: ""
     migration_vault_unseal_ca_cert: "{{ '/etc/pki/tls/certs/ca-bundle.crt' if ansible_facts.os_family == 'RedHat' else '/etc/ssl/certs/ca-certificates.crt' }}"
-    migration_common_protocol: "{{ 'https' if migration_common_tls_key and migration_common_tls_cert else 'http' }}"
+    migration_common_protocol: "{{ 'https' if (migration_common_tls_key and migration_common_tls_cert) | bool else 'http' }}"
     migration_common_api_addr: "{{ migration_common_protocol ~ '://' ~ migration_common_bind_addr ~ ':' ~ migration_common_api_port }}"
     migration_openbao_registry_url: ""
     migration_openbao_registry_username: ""

--- a/playbooks/ha_migration.yml
+++ b/playbooks/ha_migration.yml
@@ -15,7 +15,7 @@
     migration_common_tls_cert: ""
     migration_common_tls_ca: ""
     migration_vault_unseal_ca_cert: "{{ '/etc/pki/tls/certs/ca-bundle.crt' if ansible_facts.os_family == 'RedHat' else '/etc/ssl/certs/ca-certificates.crt' }}"
-    migration_common_protocol: "{{ 'https' if (migration_common_tls_key and migration_common_tls_cert) | bool else 'http' }}"
+    migration_common_protocol: "{{ 'https' if (migration_common_tls_key | length > 0) and (migration_common_tls_cert | length > 0) else 'http' }}"
     migration_common_api_addr: "{{ migration_common_protocol ~ '://' ~ migration_common_bind_addr ~ ':' ~ migration_common_api_port }}"
     migration_openbao_registry_url: ""
     migration_openbao_registry_username: ""

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -29,49 +29,48 @@ openbao_raft_leaders: []
 
 openbao_enable_ui: false
 
-openbao_config: >
-  {
-    "cluster_name": "{{ openbao_cluster_name }}",
-    "ui": "{{ openbao_enable_ui }}",
-    "api_addr": "{{ openbao_api_addr }}",
-    "cluster_addr": "{{ openbao_protocol }}://{{ openbao_cluster_addr }}",
-    "listener": [{
-      "tcp": {
-        "address": "{{ openbao_bind_addr }}:{{ openbao_api_port }}",
-        {% if openbao_tls_key and openbao_tls_cert %}
-        "tls_min_version": "tls12",
-        "tls_key_file": "/openbao/config/{{ openbao_tls_key }}",
-        "tls_cert_file": "/openbao/config/{{ openbao_tls_cert }}"
-        {% else %}
-        "tls_disable": "true"
-        {% endif %}
-      }{% if not openbao_bind_addr.startswith('127.') %},
-    },
-    {
-      "tcp": {
-        "address": "127.0.0.1:8200",
-        "tls_disable": "true"
-      }
-    {% endif %}
-    }],
-    "storage": {
-      "raft": {
-        "node_id": "raft_{{ inventory_hostname }}",
-        "path": "/openbao/file",
-        {% if openbao_raft_leaders | length > 0 %}
-        "retry_join": {
-          "leader_api_addr": "{{ openbao_protocol }}://{{ openbao_raft_leaders | first }}:{{ openbao_api_port }}"{% if openbao_tls_ca %},
-          "leader_ca_cert_file": "/openbao/config/{{ openbao_tls_ca }}"
-          {% endif %}
-        }
-        {% endif %}
-      }
-    },
-    "telemetry": {
-      "prometheus_retention_time": "30s",
-      "disable_hostname": true
-    }
-  }
+_openbao_listener_tls:
+  - tcp:
+      address: "{{ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
+      tls_min_version: "tls12"
+      tls_key_file: "{{ '/openbao/config/' ~ openbao_tls_key }}"
+      tls_cert_file: "{{ '/openbao/config/' ~ openbao_tls_cert }}"
+
+_openbao_listener_no_tls:
+  - tcp:
+      address: "{{ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
+      tls_disable: "true"
+
+_openbao_listener_local:
+  - tcp:
+      address: '127.0.0.1:8200'
+      tls_disable: 'true'
+
+_openbao_retry_join_base:
+  leader_api_addr: "{{ openbao_protocol ~ '://' ~ (openbao_raft_leaders | default(['']) | first) ~ ':' ~ openbao_api_port }}"
+
+_openbao_retry_join_tls:
+  leader_ca_cert_file: "{{ '/openbao/config/' ~ openbao_tls_ca }}"
+
+_openbao_retry_join:
+  retry_join: "{{ _openbao_retry_join_base | combine(_openbao_retry_join_tls if openbao_tls_ca else {}) }}"
+
+_openbao_raft_config:
+  node_id: "raft_{{ inventory_hostname }}"
+  path: "/openbao/file"
+
+openbao_config:
+  cluster_name: "{{ openbao_cluster_name }}"
+  ui: "{{ openbao_enable_ui }}"
+  api_addr: "{{ openbao_api_addr }}"
+  cluster_addr: "{{ openbao_protocol }}://{{ openbao_cluster_addr }}"
+  listener: "{{ (_openbao_listener_tls if (openbao_tls_key and openbao_tls_cert) else _openbao_listener_no_tls) +
+                (_openbao_listener_local if not openbao_bind_addr.startswith('127.') else []) }}"
+  storage:
+    raft: "{{ _openbao_raft_config | combine(_openbao_retry_join if openbao_raft_leaders | length > 0 else {}) }}"
+  telemetry:
+    prometheus_retention_time: "30s"
+    disable_hostname: true
 
 # Docker options
 openbao_container: {}

--- a/roles/openbao/tasks/openbao.yml
+++ b/roles/openbao/tasks/openbao.yml
@@ -1,4 +1,34 @@
 ---
+- name: Get OpenBao user id and group id
+  community.docker.docker_container:
+    name: "openbao_uid_check"
+    image: "{{ openbao_docker_image }}:{{ openbao_docker_tag }}"
+    command: "id openbao"
+    detach: false
+    cleanup: true
+  register: id_openbao_result
+  become: true
+  run_once: true
+
+- name: Set OpenBao user id and group id
+  ansible.builtin.set_fact:
+    openbao_uid: "{{ id_openbao_result.container.Output | regex_search('uid=(\\d+)', '\\1') | first }}"
+    openbao_gid: "{{ id_openbao_result.container.Output | regex_search('gid=(\\d+)', '\\1') | first }}"
+
+- name: Ensure Openbao directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0770"
+    owner: "{{ openbao_uid }}"
+    group: "{{ openbao_gid }}"
+  become: true
+  loop:
+    - "{{ openbao_config_dir }}"
+    - "{{ openbao_config_dir }}/config"
+    - "{{ openbao_config_dir }}/openbao_file"
+    - "{{ openbao_config_dir }}/openbao_logs"
+
 - name: Ensure OpenBao container is running
   docker_container:
     name: "{{ openbao_docker_name }}"

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -24,41 +24,36 @@ vault_tls_cert: ""
 
 vault_config_dir: ""
 
-vault_config: >
-  {
-    "cluster_name": "{{ vault_cluster_name }}",
-    "ui": true,
-    "api_addr": "{{ vault_api_addr }}",
-    "listener": [{
-      "tcp": {
-        "address": "{{ vault_bind_address }}:8200",
-        {% if vault_tls_key and vault_tls_cert %}
-        "tls_min_version": "tls12",
-        "tls_key_file": "/vault/config/{{ vault_tls_key }}",
-        "tls_cert_file": "/vault/config/{{ vault_tls_cert }}"
-        {% else %}
-        "tls_disable": "true"
-        {% endif %}
-      }{% if vault_bind_address != '127.0.0.1' %},
-    },
-    {
-      "tcp": {
-        "address": "127.0.0.1:8200",
-        "tls_disable": "true"
-      }
-    {% endif %}
-    }],
-    "storage": {
-    "consul": {
-       "address": "127.0.0.1:{{ consul_bind_port }}",
-       "path": "vault/"
-      }
-    },
-    "telemetry": {
-      "prometheus_retention_time": "30s",
-      "disable_hostname": true
-    }
-  }
+_vault_listener_tls:
+  - tcp:
+      address: "{{ vault_bind_address ~ ':8200' }}"
+      tls_min_version: "tls12"
+      tls_key_file: "{{ '/vault/config/' ~ vault_tls_key }}"
+      tls_cert_file: "{{ '/vault/config/' ~ vault_tls_cert }}"
+
+_vault_listener_no_tls:
+  - tcp:
+      address: "{{ vault_bind_address ~ ':8200' }}"
+      tls_disable: "true"
+
+_vault_listener_local:
+  - tcp:
+      address: '127.0.0.1:8200'
+      tls_disable: 'true'
+
+vault_config:
+  cluster_name: "{{ vault_cluster_name }}"
+  ui: true
+  api_addr: "{{ vault_api_addr }}"
+  listener: "{{ (_vault_listener_tls if (vault_tls_key and vault_tls_cert) else _vault_listener_no_tls) +
+                (_vault_listener_local if vault_bind_address != '127.0.0.1' else []) }}"
+  storage:
+    consul:
+      address: "127.0.0.1:{{ consul_bind_port }}"
+      path: "vault/"
+  telemetry:
+    prometheus_retention_time: "30s"
+    disable_hostname: true
 
 consul_bind_interface: "lo"
 consul_bind_ip: "{{ hostvars[inventory_hostname].ansible_facts[consul_bind_interface].ipv4.address }}"

--- a/roles/vault_bao_migration/defaults/main.yml
+++ b/roles/vault_bao_migration/defaults/main.yml
@@ -6,7 +6,7 @@ migration_common_tls_cert: ""
 migration_common_tls_ca: ""
 migration_vault_unseal_ca_cert: "{{ '/etc/pki/tls/certs/ca-bundle.crt' if ansible_facts.os_family == 'RedHat' else '/etc/ssl/certs/ca-certificates.crt' }}"
 
-migration_common_protocol: "{{ 'https' if (migration_common_tls_key and migration_common_tls_cert) | bool else 'http' }}"
+migration_common_protocol: "{{ 'https' if (migration_common_tls_key | length > 0) and (migration_common_tls_cert | length > 0) else 'http' }}"
 
 migration_common_api_addr: "{{ migration_common_protocol ~ '://' ~ migration_common_bind_addr ~ ':' ~ migration_common_api_port }}"
 migration_common_bind_addr: "127.0.0.1"
@@ -86,7 +86,7 @@ migration_vault_raft_config:
   ui: true
   api_addr: "{{ migration_common_api_addr }}"
   cluster_addr: "{{ migration_common_protocol }}://{{ migration_common_cluster_addr }}"
-  listener: "{{ (_migration_listener_tls if ((migration_common_tls_key and migration_common_tls_cert) | bool) else _migration_listener_no_tls) +
+  listener: "{{ (_migration_listener_tls if ((migration_common_tls_key | length > 0) and (migration_common_tls_cert | length > 0)) else _migration_listener_no_tls) +
                 (_migration_listener_local if migration_common_bind_addr != '127.0.0.1' else []) }}"
   storage:
     raft: "{{ _migration_raft_config | combine(_migration_retry_join if _vault_followers | length > 0 else {}) }}"

--- a/roles/vault_bao_migration/defaults/main.yml
+++ b/roles/vault_bao_migration/defaults/main.yml
@@ -6,7 +6,7 @@ migration_common_tls_cert: ""
 migration_common_tls_ca: ""
 migration_vault_unseal_ca_cert: "{{ '/etc/pki/tls/certs/ca-bundle.crt' if ansible_facts.os_family == 'RedHat' else '/etc/ssl/certs/ca-certificates.crt' }}"
 
-migration_common_protocol: "{{ 'https' if migration_common_tls_key and migration_common_tls_cert else 'http' }}"
+migration_common_protocol: "{{ 'https' if (migration_common_tls_key and migration_common_tls_cert) | bool else 'http' }}"
 
 migration_common_api_addr: "{{ migration_common_protocol ~ '://' ~ migration_common_bind_addr ~ ':' ~ migration_common_api_port }}"
 migration_common_bind_addr: "127.0.0.1"
@@ -51,48 +51,48 @@ _vault_nodes: []
 _vault_leader: {}
 _vault_followers: []
 
-migration_vault_raft_config: >
-  {
-    "cluster_name": "{{ migration_common_cluster_name }}",
-    "ui": true,
-    "api_addr": "{{ migration_common_api_addr }}",
-    "cluster_addr": "{{ migration_common_protocol }}://{{ migration_common_cluster_addr }}",
-    "listener": [{
-      "tcp": {
-        "address": "{{ migration_common_bind_addr }}:8200",
-        {% if migration_common_tls_key and migration_common_tls_cert %}
-        "tls_min_version": "tls12",
-        "tls_key_file": "/vault/config/{{ migration_common_tls_key }}",
-        "tls_cert_file": "/vault/config/{{ migration_common_tls_cert }}"
-        {% else %}
-        "tls_disable": "true"
-        {% endif %}
-      }{% if migration_common_bind_addr != '127.0.0.1' %},
-    },
-    {
-      "tcp": {
-        "address": "127.0.0.1:8200",
-        "tls_disable": "true"
-      }
-    {% endif %}
-    }],
-    "storage": {
-      "raft": {
-        "path": "/vault/file/",
-        "node_id": "raft_{{ inventory_hostname }}"{% if _vault_followers | length > 0 %},
-        "retry_join": {
-          "leader_api_addr": "{{ _vault_leader.api_address }}"{% if migration_common_tls_ca %},
-          "leader_ca_cert_file": "/vault/config/{{ migration_common_tls_ca }}"
-          {% endif %}
-        }
-        {% endif %}
-      }
-    },
-    "telemetry": {
-      "prometheus_retention_time": "30s",
-      "disable_hostname": true
-    }
-  }
+_migration_listener_tls:
+  - tcp:
+      address: "{{ migration_common_bind_addr ~ ':8200' }}"
+      tls_min_version: "tls12"
+      tls_key_file: "{{ '/vault/config/' ~ migration_common_tls_key }}"
+      tls_cert_file: "{{ '/vault/config/' ~ migration_common_tls_cert }}"
+
+_migration_listener_no_tls:
+  - tcp:
+      address: "{{ migration_common_bind_addr ~ ':8200' }}"
+      tls_disable: "true"
+
+_migration_listener_local:
+  - tcp:
+      address: '127.0.0.1:8200'
+      tls_disable: 'true'
+
+_migration_retry_join_base:
+  leader_api_addr: "{{ _vault_leader.api_address | default('') }}"
+
+_migration_retry_join_tls:
+  leader_ca_cert_file: "{{ '/vault/config/' ~ migration_common_tls_ca }}"
+
+_migration_retry_join:
+  retry_join: "{{ _migration_retry_join_base | combine(_migration_retry_join_tls if migration_common_tls_ca else {}) }}"
+
+_migration_raft_config:
+  path: "/vault/file/"
+  node_id: "raft_{{ inventory_hostname }}"
+
+migration_vault_raft_config:
+  cluster_name: "{{ migration_common_cluster_name }}"
+  ui: true
+  api_addr: "{{ migration_common_api_addr }}"
+  cluster_addr: "{{ migration_common_protocol }}://{{ migration_common_cluster_addr }}"
+  listener: "{{ (_migration_listener_tls if ((migration_common_tls_key and migration_common_tls_cert) | bool) else _migration_listener_no_tls) +
+                (_migration_listener_local if migration_common_bind_addr != '127.0.0.1' else []) }}"
+  storage:
+    raft: "{{ _migration_raft_config | combine(_migration_retry_join if _vault_followers | length > 0 else {}) }}"
+  telemetry:
+    prometheus_retention_time: "30s"
+    disable_hostname: true
 
 # Vault Docker options for when restarting Vault container with Raft
 migration_vault_container_options: {}

--- a/roles/vault_bao_migration/tasks/prereqs.yml
+++ b/roles/vault_bao_migration/tasks/prereqs.yml
@@ -72,10 +72,10 @@
     owner: "{{ openbao_uid }}"
     group: "{{ openbao_gid }}"
   become: true
-  when: ((migration_common_tls_key and migration_common_tls_cert) | bool) or migration_common_tls_ca
+  when: ((migration_common_tls_key | length > 0) and (migration_common_tls_cert | length > 0)) or migration_common_tls_ca | length > 0
 
 - name: Copy TLS certificates from Vault to OpenBao
-  when: (migration_common_tls_key and migration_common_tls_cert) | bool
+  when: (migration_common_tls_key | length > 0) and (migration_common_tls_cert | length > 0)
   become: true
   block:
     - name: Copy TLS key
@@ -103,5 +103,5 @@
     owner: "{{ openbao_uid }}"
     group: "{{ openbao_gid }}"
     mode: '0600'
-  when: migration_common_tls_ca
+  when: migration_common_tls_ca | length > 0
   become: true

--- a/roles/vault_bao_migration/tasks/prereqs.yml
+++ b/roles/vault_bao_migration/tasks/prereqs.yml
@@ -72,10 +72,10 @@
     owner: "{{ openbao_uid }}"
     group: "{{ openbao_gid }}"
   become: true
-  when: (migration_common_tls_key and migration_common_tls_cert) or migration_common_tls_ca
+  when: ((migration_common_tls_key and migration_common_tls_cert) | bool) or migration_common_tls_ca
 
 - name: Copy TLS certificates from Vault to OpenBao
-  when: migration_common_tls_key and migration_common_tls_cert
+  when: (migration_common_tls_key and migration_common_tls_cert) | bool
   become: true
   block:
     - name: Copy TLS key

--- a/tests/test_openbao.yml
+++ b/tests/test_openbao.yml
@@ -14,13 +14,6 @@
       ansible.builtin.debug:
         var: openbao_api_addr
 
-    - name: Ensure /etc/openbao exists
-      ansible.builtin.file:
-        path: /etc/openbao
-        state: directory
-        mode: "0700"
-      become: true
-
     - name: Include openbao role
       ansible.builtin.include_role:
         name: openbao

--- a/tests/test_openbao_ha.yml
+++ b/tests/test_openbao_ha.yml
@@ -18,13 +18,6 @@
       ansible.builtin.debug:
         var: openbao_api_addr
 
-    - name: Ensure /etc/openbao exists
-      ansible.builtin.file:
-        path: /etc/openbao
-        state: directory
-        mode: "0700"
-      become: true
-
     - name: Include openbao role
       ansible.builtin.include_role:
         name: openbao


### PR DESCRIPTION
Since the config is already json formatted, the to_json filter seems to cause it to template incorrectly.

Found this in a Gazpacho multinode, so it's probably to do with the newer ansible version running there.

Without this, the vault container gets stuck in boot loop with something like this spamming in the logs:
```
error loading configuration from /vault/config: error loading "/vault/config/local.json": At 2:1: key '"{\n  \"cluster_name\": \"seed\",\n  \"ui\": true,\n  \"api_addr\": \"http://127.0.0.1:8200\",\n  \"listener\": [{\n    \"tcp\": {\n      \"address\": \"127.0.0.1:8200\",\n            \"tls_disable\": \"true\"\n          }  }],\n  \"storage\": {\n  \"consul\": {\n     \"address\": \"127.0.0.1:8500\",\n     \"path\": \"vault/\"\n    }\n  },\n  \"telemetry\": {\n    \"prometheus_retention_time\": \"30s\",\n    \"disable_hostname\": true\n  }\n}\n"' expected start of object ('{') or assignment ('=') 
```
And the config file at `/opt/kayobe/local.json` shows the same, with quotes, `\n`s and all that