### PR TITLE
Allow for unauthenticated metric collection in openbao

### DIFF
--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -40,7 +40,8 @@ Role variables
     * `openbao_write_keys_file_host`: Host on which to write root token and unseal keys. Default `localhost`
     * `openbao_write_keys_file_path`: Path of file to write root token and unseal keys. Default `bao-keys.json`
     * `openbao_raft_leaders`: List of IPs belonging to Raft leaders. Expected that the first and only entry is the IP address of the first OpenBao instance as this would be initialised whereas as the others will not.
-    * `openbao_enable_ui`: Whether to enable user interface that could be accessed from the `openbao_api_addr`. Default `false` 
+    * `openbao_enable_ui`: Whether to enable user interface that could be accessed from the `openbao_api_addr`. Default `false`
+    * `openbao_unauthenticated_metrics_access`: Whether to allow unauthenticated access to metrics on the OpenBao listener. Default `true`
 
 Root and unseal keys
 --------------------

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -28,12 +28,13 @@ openbao_cluster_port: 8201
 openbao_raft_leaders: []
 
 openbao_enable_ui: false
+openbao_unauthenticated_metrics_access: true
 
 _openbao_listener_tls:
   - tcp:
       address: "{{ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
       telemetry:
-        unauthenticated_metrics_access: true
+        unauthenticated_metrics_access: "{{ openbao_unauthenticated_metrics_access | bool }}"
       tls_min_version: "tls12"
       tls_key_file: "{{ '/openbao/config/' ~ openbao_tls_key }}"
       tls_cert_file: "{{ '/openbao/config/' ~ openbao_tls_cert }}"
@@ -42,7 +43,7 @@ _openbao_listener_no_tls:
   - tcp:
       address: "{{ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
       telemetry:
-        unauthenticated_metrics_access: true
+        unauthenticated_metrics_access: "{{ openbao_unauthenticated_metrics_access | bool }}"
       tls_disable: "true"
 
 _openbao_listener_local:

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -32,6 +32,8 @@ openbao_enable_ui: false
 _openbao_listener_tls:
   - tcp:
       address: "{{ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
+      telemetry:
+        unauthenticated_metrics_access: true
       tls_min_version: "tls12"
       tls_key_file: "{{ '/openbao/config/' ~ openbao_tls_key }}"
       tls_cert_file: "{{ '/openbao/config/' ~ openbao_tls_cert }}"
@@ -39,6 +41,8 @@ _openbao_listener_tls:
 _openbao_listener_no_tls:
   - tcp:
       address: "{{ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
+      telemetry:
+        unauthenticated_metrics_access: true
       tls_disable: "true"
 
 _openbao_listener_local:


### PR DESCRIPTION
By default openbao telemetry requires generating a token and passing that to prometheus in order to scrape metrics. This adds unnecessary friction to the scraping process. In addition to this none of the metrics are sensitive in comparison to the other metrics we scrape on clouds.