### PR TITLE
fix openbao api address

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -17,7 +17,7 @@ openbao_tls_ca: ""
 
 openbao_protocol: "{{ 'https' if openbao_tls_key and openbao_tls_cert else 'http' }}"
 
-openbao_api_addr: "{{ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
+openbao_api_addr: "{{ 'http' ~ '://' ~ openbao_bind_addr ~ ':' ~ openbao_api_port }}"
 openbao_bind_addr: "127.0.0.1"
 openbao_init_addr: "{{ openbao_api_addr }}"
 openbao_cluster_addr: "{{ openbao_bind_addr ~ ':' ~ openbao_cluster_port }}"


### PR DESCRIPTION
fixes this error:
```
 Error initializing core: redirect address is not valid url: parse

"127.0.0.1:8200" first path segment in URL cannot contain colon 
```